### PR TITLE
Check reserved bits in non-leaf PTEs

### DIFF
--- a/src/mmu/hptw.sv
+++ b/src/mmu/hptw.sv
@@ -156,7 +156,7 @@ module hptw import cvw::*;  #(parameter cvw_t P) (
   flopenr #(P.XLEN) PTEReg(clk, reset, PRegEn, NextPTE2, PTE); // Capture page table entry from data cache
 
   // Assign PTE descriptors common across all XLEN values
-  // For non-leaf PTEs, D, A, U bits are reserved and ignored.  They do not cause faults while walking the page table
+  // For non-leaf PTEs, D, A, U bits are reserved and cause faults while walking the page table
   assign {PTE_U, Executable, Writable, Readable, Valid} = PTE[4:0];
   assign LeafPTE = Executable | Writable | Readable;
   assign ValidPTE = Valid & ~(Writable & ~Readable);

--- a/src/mmu/hptw.sv
+++ b/src/mmu/hptw.sv
@@ -162,7 +162,7 @@ module hptw import cvw::*;  #(parameter cvw_t P) (
   assign ValidPTE = Valid & ~(Writable & ~Readable);
   assign ValidLeafPTE = ValidPTE & LeafPTE;
   assign ValidNonLeafPTE = Valid & ~LeafPTE;
-  if(P.XLEN == 64) assign PBMTFaultM = ValidNonLeafPTE & (|PTE[62:61]);
+  if(P.XLEN == 64) assign PBMTFaultM = ValidNonLeafPTE & (|PTE[63:54]);
   else assign PBMTFaultM = 1'b0;
   assign DAUFaultM = ValidNonLeafPTE & (|PTE[7:6] | PTE[4]);
 


### PR DESCRIPTION
Non-leaf checking covered PBMT but ignored N plus reserved bits. Check `PTE[63:54]`.