### PR TITLE
Add Table 10.2 ClearDirty erratum

### DIFF
--- a/errata.md
+++ b/errata.md
@@ -20,4 +20,5 @@ Please contribute by making a pull request to modify this document on GitHub.  S
 | 367 | 8.4.1 | "Uses the CSRs (xtvect)" | Replace "xtvect" with "xtvec". | Sotaro Fujimoto, Japan | 6/19/26 |
 | 388 | Fig. 9.6 | The top-left controller label is shown as "Controller1". | Replace with "Controller 1". | Sotaro Fujimoto, Japan | 7/14/26 |
 | 394 | sidebar | "Fig. 20.3 shows a full-featured GPIO peripheral with an APB interface." | Replace "Fig. 20.3" with "Fig. 20.4". | Sotaro Fujimoto, Japan | 7/19/26 |
+| 455 | Table 10.2, `ClearDirty` row | The flush condition is listed as `(Flush & ~LineDirty)`. | Change it to `(Flush & LineDirty)`, consistent with Section 10.4.5.4 and `cachefsm.sv`. | 王晗宇, China | 9/2/26 |
 | 885   | 23.2.2.4-5 | The ramspeed benchmark is no longer supported and has been removed from the Buildroot Linux image. | n/a | David Harris, Claremont, CA | 1/4/26 |


### PR DESCRIPTION
Table 10.2 on page 455 lists the ClearDirty flush criterion as `(Flush & ~LineDirty)`. It should be `(Flush & LineDirty)`.

This matches Section 10.4.5.4, which states that ClearDirty is asserted on the transition from Flush to FlushWriteback, and the condition in `cachefsm.sv`.

Reported by 王晗宇, China.