### PR TITLE
nonleaf reserved tests

### DIFF
--- a/sim/questa/wave.do
+++ b/sim/questa/wave.do
@@ -431,7 +431,7 @@ add wave -noupdate -expand -group lsu -group ptwalker -expand -group faults /tes
 add wave -noupdate -expand -group lsu -group ptwalker -expand -group faults /testbench/dut/core/lsu/hptw/hptw/LoadAccessFaultM
 add wave -noupdate -expand -group lsu -group ptwalker -expand -group faults /testbench/dut/core/lsu/hptw/hptw/StoreAmoAccessFaultM
 add wave -noupdate -expand -group lsu -group ptwalker -expand -group faults /testbench/dut/core/lsu/hptw/hptw/HPTWInstrAccessFault
-add wave -noupdate -expand -group lsu -group ptwalker -expand -group faults /testbench/dut/core/lsu/hptw/hptw/PBMTFaultM
+add wave -noupdate -expand -group lsu -group ptwalker -expand -group faults /testbench/dut/core/lsu/hptw/hptw/NonLeafReservedFaultM
 add wave -noupdate -group {WriteBack stage} /testbench/InstrW
 add wave -noupdate -group {WriteBack stage} /testbench/InstrWName
 add wave -noupdate -group {WriteBack stage} /testbench/dut/core/priv/priv/pmd/wfiW

--- a/src/mmu/hptw.sv
+++ b/src/mmu/hptw.sv
@@ -109,21 +109,21 @@ module hptw import cvw::*;  #(parameter cvw_t P) (
   logic                     HPTWLoadPageFaultDelay, HPTWStoreAmoPageFaultDelay, HPTWInstrPageFaultDelay;
   logic                     HPTWAccessFaultDelay;
   logic                     TakeHPTWFault;
-  logic                     PBMTFaultM;
+  logic                     NonLeafReservedFaultM;
   logic                     DAUFaultM;
-  logic                     PBMTOrDAUFaultM;
+  logic                     NonLeafPageFaultM;
   logic                     HPTWFaultM;
 
   // map hptw access faults onto either the original LSU load/store fault or instruction access fault
   assign LSUAccessFaultM         = LSULoadAccessFaultM | LSUStoreAmoAccessFaultM;
-  assign PBMTOrDAUFaultM         = PBMTFaultM | DAUFaultM;
-  assign HPTWFaultM              = LSUAccessFaultM | PBMTOrDAUFaultM;
+  assign NonLeafPageFaultM       = NonLeafReservedFaultM | DAUFaultM;
+  assign HPTWFaultM              = LSUAccessFaultM | NonLeafPageFaultM;
   assign HPTWLoadAccessFault     = LSUAccessFaultM & DTLBWalk & MemRWM[1] & ~MemRWM[0];
   assign HPTWStoreAmoAccessFault = LSUAccessFaultM & DTLBWalk & (MemRWM[0] | (|CMOpM));
   assign HPTWInstrAccessFault    = LSUAccessFaultM & ~DTLBWalk;
-  assign HPTWLoadPageFault       = PBMTOrDAUFaultM & DTLBWalk & MemRWM[1] & ~MemRWM[0];
-  assign HPTWStoreAmoPageFault   = PBMTOrDAUFaultM & DTLBWalk & (MemRWM[0] | (|CMOpM));
-  assign HPTWInstrPageFault      = PBMTOrDAUFaultM & ~DTLBWalk;
+  assign HPTWLoadPageFault       = NonLeafPageFaultM & DTLBWalk & MemRWM[1] & ~MemRWM[0];
+  assign HPTWStoreAmoPageFault   = NonLeafPageFaultM & DTLBWalk & (MemRWM[0] | (|CMOpM));
+  assign HPTWInstrPageFault      = NonLeafPageFaultM & ~DTLBWalk;
 
   flopr #(6) HPTWAccesFaultReg(clk, reset, {HPTWLoadAccessFault, HPTWStoreAmoAccessFault, HPTWInstrAccessFault,
                                             HPTWLoadPageFault, HPTWStoreAmoPageFault, HPTWInstrPageFault},
@@ -156,14 +156,17 @@ module hptw import cvw::*;  #(parameter cvw_t P) (
   flopenr #(P.XLEN) PTEReg(clk, reset, PRegEn, NextPTE2, PTE); // Capture page table entry from data cache
 
   // Assign PTE descriptors common across all XLEN values
-  // For non-leaf PTEs, D, A, U bits are reserved and cause faults while walking the page table
+  // For non-leaf PTEs, D, A, U bits (7:6, 4) are reserved and cause faults while walking the page table.
+  // Likewise, N (63), PBMT (62:61), and reserved (60:54) bits must be zero in non-leaf PTEs regardless of
+  // whether Svnapot/Svpbmt are supported (privileged spec: "these bits remain reserved and must be zeroed
+  // in non-leaf PTEs")
   assign {PTE_U, Executable, Writable, Readable, Valid} = PTE[4:0];
   assign LeafPTE = Executable | Writable | Readable;
   assign ValidPTE = Valid & ~(Writable & ~Readable);
   assign ValidLeafPTE = ValidPTE & LeafPTE;
   assign ValidNonLeafPTE = Valid & ~LeafPTE;
-  if(P.XLEN == 64) assign PBMTFaultM = ValidNonLeafPTE & (|PTE[63:54]);
-  else assign PBMTFaultM = 1'b0;
+  if(P.XLEN == 64) assign NonLeafReservedFaultM = ValidNonLeafPTE & (|PTE[63:54]);
+  else assign NonLeafReservedFaultM = 1'b0;
   assign DAUFaultM = ValidNonLeafPTE & (|PTE[7:6] | PTE[4]);
 
   if(P.SVADU_SUPPORTED) begin : hptwwrites

--- a/tests/coverage/nonleafpbmtfault.S
+++ b/tests/coverage/nonleafpbmtfault.S
@@ -1,10 +1,11 @@
 ///////////////////////////////////////////
-// hptwAccessFault.S
+// nonleafpbmtfault.S
 //
 // Written: Rose Thompson rose@rosethompson.net
 //
-// Purpose: Force the HPTW to walk a page table with non-leaf non-zero PBMT bits.  This will generate
-// a load or store/amo page fault based on the original access type.
+// Purpose: Force the HPTW to walk page tables with non-leaf PTEs that have nonzero bits in 63:54:
+// N (63), each PBMT bit (62, 61), and each reserved bit (60:54) individually.  Each generates a
+// load or store/amo page fault based on the original access type.
 //
 // A component of the CORE-V-WALLY configurable RISC-V project.
 // https://github.com/openhwgroup/cvw
@@ -50,6 +51,28 @@ main:
     add t0, t0, t2
     sw t1, 0(t0)      # valid virtual address, valid physical address, but invalid PBMT in middle of page table.
 
+    li t0, 0x8040000000
+    lw t1, 0(t0)      # walk hits non-leaf PTE with N bit (63) set: load page fault
+    sw t1, 0(t0)      # same PTE: store/amo page fault
+
+    li t0, 0x80C0000000
+    lw t1, 0(t0)      # non-leaf PTE with PBMT bit 61 set: load page fault
+    li t0, 0x8100000000
+    lw t1, 0(t0)      # non-leaf PTE with reserved bit 60 set: load page fault
+    li t0, 0x8140000000
+    lw t1, 0(t0)      # non-leaf PTE with reserved bit 59 set: load page fault
+    li t0, 0x8180000000
+    lw t1, 0(t0)      # non-leaf PTE with reserved bit 58 set: load page fault
+    li t0, 0x81C0000000
+    lw t1, 0(t0)      # non-leaf PTE with reserved bit 57 set: load page fault
+    li t0, 0x8200000000
+    lw t1, 0(t0)      # non-leaf PTE with reserved bit 56 set: load page fault
+    li t0, 0x8240000000
+    lw t1, 0(t0)      # non-leaf PTE with reserved bit 55 set: load page fault
+
+    li t0, 0x80200000
+    lw t1, 0(t0)      # walk hits non-leaf PTE with reserved bit (54) set: load page fault
+
     fence.I
 
 finished:
@@ -64,13 +87,21 @@ pagetable:
     .8byte 0x20004401
 
 .align 12
-    .8byte 0x4000004020004801
-    .8byte 0x0000000020004801
-    .8byte 0x0000000020004801
+    .8byte 0x4000004020004801   # idx0: non-leaf with PBMT bit 62 set: faults
+    .8byte 0x8000000020004801   # idx1: non-leaf with N bit (63) set: faults
+    .8byte 0x0000000020004801   # idx2: valid non-leaf (used by code/data mappings)
+    .8byte 0x2000000020004801   # idx3: non-leaf with PBMT bit 61 set: faults
+    .8byte 0x1000000020004801   # idx4: non-leaf with reserved bit 60 set: faults
+    .8byte 0x0800000020004801   # idx5: non-leaf with reserved bit 59 set: faults
+    .8byte 0x0400000020004801   # idx6: non-leaf with reserved bit 58 set: faults
+    .8byte 0x0200000020004801   # idx7: non-leaf with reserved bit 57 set: faults
+    .8byte 0x0100000020004801   # idx8: non-leaf with reserved bit 56 set: faults
+    .8byte 0x0080000020004801   # idx9: non-leaf with reserved bit 55 set: faults
 
 
 .align 12
     .8byte 0x0000000020004C01
+    .8byte 0x0040000020004C01   # non-leaf with reserved bit (54) set: faults
 
 .align 12
     #80000000


### PR DESCRIPTION
Adds code coverage tests for nonleaf reserved PTE fields that should cause traps.

Cleans up naming of signals that check these fields.