### PR TITLE
Fix xtval for ebreak on a straddling fetch (#1832 part 2)

### DIFF
--- a/src/privileged/csr.sv
+++ b/src/privileged/csr.sv
@@ -141,7 +141,8 @@ module csr import cvw::*;  #(parameter cvw_t P) (
   always_comb
     if (InterruptM)           NextFaultXtvalM = '0;
     else case (CauseM)
-      12, 1, 3:               NextFaultXtvalM = PCSpillM;  // Instruction page/access faults, breakpoint
+      12, 1:                  NextFaultXtvalM = PCSpillM;  // Instruction page/access faults report the faulting half of a spilled fetch
+      3:                      NextFaultXtvalM = PCM;       // Breakpoint reports the address of the ebreak itself, not the second half of a spilled fetch
       2:                      NextFaultXtvalM = {{(P.XLEN-32){1'b0}}, InstrOrigM}; // Illegal instruction fault
       0, 4, 6, 13, 15, 5, 7:  NextFaultXtvalM = IEUAdrxTvalM; // Instruction misaligned, Load/Store Misaligned/page/access faults
       default:                NextFaultXtvalM = '0; // Ecall, interrupts


### PR DESCRIPTION
An uncompressed ebreak whose fetch spills -- PC mod 64 == 0x3E on a config with an I-cache, or any 2 mod 4 address when the fetch is uncached -- reported xtval = PC+2, because cause 3 shared the PCSpillM case arm with the instruction page and access faults. The spec requires mtval to be either zero or the virtual address of the ebreak itself, and PC+2 is neither.

Split cause 3 out and give it PCM. Causes 12 and 1 keep PCSpillM, which is correct for them: they must report the portion of the instruction that faulted, not the start of the instruction.

Claude-Session: https://claude.ai/code/session_01AY8Abv6UWr9oRxTTpX58cv