### PR TITLE
IFU: report a fetch fault on the first half of a spilled instruction (#1838 item 1)

### DIFF
--- a/src/ifu/ifu.sv
+++ b/src/ifu/ifu.sv
@@ -142,6 +142,7 @@ module ifu import cvw::*;  #(parameter cvw_t P) (
   logic [31:0]                 ShiftUncachedInstr;
   logic                        ITLBMissF;
   logic                        InstrUpdateAF;                            // ITLB hit needs to update dirty or access bits
+  logic                        InstrPageFaultRawF, InstrAccessFaultRawF; // Faults on the half of the fetch currently being translated
 
   assign PCFExt = {2'b00, PCSpillF};
 
@@ -153,9 +154,14 @@ module ifu import cvw::*;  #(parameter cvw_t P) (
     logic [P.XLEN-1:0] PCSpillD, PCSpillE;
     logic [P.XLEN-1:0] PCIncrM;
     logic              SelSpillF, SelSpillD, SelSpillE, SelSpillM;
+    logic              FirstHalfFaultF;
     spill #(P) spill(.clk, .reset, .StallF, .FlushD, .PCF, .PCPlus4F, .PCNextF, .InstrRawF,  .CacheableF,
-      .IFUCacheBusStallF, .ITLBMissOrUpdateAF, .PCSpillNextF, .PCSpillF, .SelSpillNextF, .SelSpillF, .PostSpillInstrRawF, .CompressedF);
-    flopenr #(1) SpillDReg(clk, reset, ~StallD, SelSpillF, SelSpillD);
+      .InstrPageFaultF(InstrPageFaultRawF), .InstrAccessFaultF(InstrAccessFaultRawF),
+      .IFUCacheBusStallF, .ITLBMissOrUpdateAF, .PCSpillNextF, .PCSpillF, .SelSpillNextF, .SelSpillF,
+      .InstrPageFaultSpillF(InstrPageFaultF), .InstrAccessFaultSpillF(InstrAccessFaultF), .FirstHalfFaultF,
+      .PostSpillInstrRawF, .CompressedF);
+    // A fault on the first half is reported at PCM, not PCM+2, so clear the spill flag that adds the +2 in xtval
+    flopenr #(1) SpillDReg(clk, reset, ~StallD, SelSpillF & ~FirstHalfFaultF, SelSpillD);
     flopenr #(1) SpillEReg(clk, reset, ~StallE, SelSpillD, SelSpillE);
     flopenr #(1) SpillMReg(clk, reset, ~StallM, SelSpillE, SelSpillM);
     assign PCIncrM = PCM + 'd2;
@@ -167,6 +173,8 @@ module ifu import cvw::*;  #(parameter cvw_t P) (
     assign PostSpillInstrRawF = InstrRawF;
     assign {SelSpillNextF, CompressedF} = '0;
     assign PCSpillM = PCM;
+    assign InstrPageFaultF = InstrPageFaultRawF;
+    assign InstrAccessFaultF = InstrAccessFaultRawF;
   end
 
   ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -198,8 +206,8 @@ module ifu import cvw::*;  #(parameter cvw_t P) (
          .PhysicalAddress(PCPF),
          .TLBMiss(ITLBMissF),
          .Cacheable(CacheableF), .Idempotent(), .SelTIM(SelIROM),
-         .InstrAccessFaultF, .LoadAccessFaultM(), .StoreAmoAccessFaultM(),
-         .InstrPageFaultF, .LoadPageFaultM(), .StoreAmoPageFaultM(),
+         .InstrAccessFaultF(InstrAccessFaultRawF), .LoadAccessFaultM(), .StoreAmoAccessFaultM(),
+         .InstrPageFaultF(InstrPageFaultRawF), .LoadPageFaultM(), .StoreAmoPageFaultM(),
          .LoadMisalignedFaultM(), .StoreAmoMisalignedFaultM(),
          .UpdateDA(InstrUpdateAF), .CMOpM(4'b0),
          .AtomicAccessM(1'b0),.ExecuteAccessF(1'b1), .WriteAccessM(1'b0), .ReadAccessM(1'b0),
@@ -207,7 +215,7 @@ module ifu import cvw::*;  #(parameter cvw_t P) (
 
      assign ITLBMissOrUpdateAF = ITLBMissF | (P.SVADU_SUPPORTED & InstrUpdateAF);
   end else begin
-    assign {ITLBMissF, InstrAccessFaultF, InstrPageFaultF, InstrUpdateAF} = '0;
+    assign {ITLBMissF, InstrAccessFaultRawF, InstrPageFaultRawF, InstrUpdateAF} = '0;
     assign PCPF = PCFExt[P.PA_BITS-1:0];
     assign CacheableF = 1'b1;
     assign SelIROM = '0;

--- a/src/ifu/spill.sv
+++ b/src/ifu/spill.sv
@@ -41,10 +41,15 @@ module spill import cvw::*;  #(parameter cvw_t P) (
   input logic               IFUCacheBusStallF, // I$ or bus are stalled. Transition to second fetch of spill after the first is fetched
   input logic               ITLBMissOrUpdateAF, // ITLB miss causes HPTW (hardware pagetable walker) walk or update access bit
   input logic               CacheableF,        // Is the instruction from the cache?
+  input logic               InstrPageFaultF,   // Page fault on the half currently being fetched
+  input logic               InstrAccessFaultF, // Access fault on the half currently being fetched
   output logic [P.XLEN-1:0] PCSpillNextF,      // The next PCF for one of the two memory addresses of the spill
   output logic [P.XLEN-1:0] PCSpillF,          // PCF for one of the two memory addresses of the spill
   output logic              SelSpillNextF,     // During the transition between the two spill operations, the IFU should stall the pipeline
   output logic              SelSpillF,         // Select incremented PC on a spill
+  output logic              InstrPageFaultSpillF,   // Page fault on either half of the spilled fetch
+  output logic              InstrAccessFaultSpillF, // Access fault on either half of the spilled fetch
+  output logic              FirstHalfFaultF,   // The first half of the spilled fetch faulted, so it is the portion to report in xtval
   output logic [31:0]       PostSpillInstrRawF,// The final 32 bit instruction after merging the two spilled fetches into 1 instruction
   output logic              CompressedF);      // The fetched instruction is compressed
 
@@ -58,6 +63,7 @@ module spill import cvw::*;  #(parameter cvw_t P) (
   logic              SpillSaveF;
   logic [15:0]       InstrFirstHalfF;
   logic              EarlyCompressedF;
+  logic              FirstHalfPageFaultF, FirstHalfAccessFaultF;
 
   ////////////////////////////////////////////////////////////////////////////////////////////////////
   // PC logic
@@ -111,6 +117,16 @@ module spill import cvw::*;  #(parameter cvw_t P) (
 
   // save the first 2 bytes
   flopenr #(16) SpillInstrReg(clk, reset, SpillSaveF, InstrRawF[15:0], InstrFirstHalfF);
+
+  // Save the fetch fault status of the first half.  The second half is translated and checked at
+  // PCF+2 in the next cycle, so without this the first half's fault would be lost whenever the
+  // second half fetches cleanly.  Qualifying with SelSpillF drops the latched status on a FlushD,
+  // which returns the state machine to STATE_READY.
+  flopenr #(2) SpillFaultReg(clk, reset, SpillSaveF, {InstrPageFaultF, InstrAccessFaultF},
+                             {FirstHalfPageFaultF, FirstHalfAccessFaultF});
+  assign InstrPageFaultSpillF   = InstrPageFaultF   | (SelSpillF & FirstHalfPageFaultF);
+  assign InstrAccessFaultSpillF = InstrAccessFaultF | (SelSpillF & FirstHalfAccessFaultF);
+  assign FirstHalfFaultF        = SelSpillF & (FirstHalfPageFaultF | FirstHalfAccessFaultF);
 
   // merge together
   mux2 #(32) postspillmux(InstrRawF, {InstrRawF[15:0], InstrFirstHalfF}, SelSpillF, PostSpillInstrRawF);


### PR DESCRIPTION
Issue #1838 item 1.

A fetch fault on the first half of a 32-bit instruction that spills across a cache line or page was discarded, because taking the spill stalls D and `faultregD` is the only register that samples the F-stage fault bits. When the first half faulted and the second did not, no exception was raised and the core executed a word merged from two bytes of the protected page.

`spill.sv` now latches the first half's fault status on the existing `SpillSaveF` enable and ORs it back while `SelSpillF` is asserted. `ifu.sv` clears the spill flag feeding `xtval` when the first half faulted, so `xtval` reports `PCM` rather than `PCM+2` — completing the cause-12/1 half of item 2, whose `ebreak` half landed in b787dd19a.

Suppressing `TakeSpillF` instead would be shorter, but it grafts the PMP priority decode onto the `StallF`/`D`/`E`/`M`/`W` network, roughly nine levels past where `CacheableF` already arrives. The commit message explains the tradeoff.

Independent of the other three PRs for this issue; they apply in any order.

**Verification:** `lint-wally` and `lint-wally --nightly` clean. The arch tests could not be rebuilt here (the installed `sail_riscv_sim` no longer accepts `--trace-all`), so all 44 `tests/coverage` ELFs were run on rv64gc against `main`: all 44 cycle-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013H8QE6RS2J9nJu1x4sThUh
