### PR TITLE
IFU: clear InstrMisalignedFaultM on FlushM (#1838 item 4)

### DIFF
--- a/src/ifu/ifu.sv
+++ b/src/ifu/ifu.sv
@@ -403,7 +403,7 @@ module ifu import cvw::*;  #(parameter cvw_t P) (
   // Spec 3.1.14
   // Traps: Can’t happen.  The bottom two bits of MTVEC are ignored so the trap always is to a multiple of 4.  See 3.1.7 of the privileged spec.
   assign InstrMisalignedFaultE = (IEUAdrE[1] & ~P.ZCA_SUPPORTED) & PCSrcE;
-  flopenr #(1) InstrMisalignedReg(clk, reset, ~StallM, InstrMisalignedFaultE, InstrMisalignedFaultM);
+  flopenrc #(1) InstrMisalignedReg(clk, reset, FlushM, ~StallM, InstrMisalignedFaultE, InstrMisalignedFaultM);
 
   // Instruction and PC pipeline registers flush to NOP, not zero
   mux2    #(32)     FlushInstrEMux(InstrD, nop, FlushE, NextInstrD);


### PR DESCRIPTION
Issue #1838 item 4.

`InstrMisalignedReg` was the only E→M fault register without a flush clear. When a trap, xRET or CSR write fence flushed E and M, the squashed misaligned jump still set `InstrMisalignedFaultM`, and since `ExceptionM` is not qualified by `InstrValidM`, a spurious cause-0 trap fired immediately after the handler entry or `mret`.

Switching to `flopenrc` makes it behave exactly like `faultregM` in `privpiperegs.sv`, which carries the sibling instruction faults with the same `(FlushM, ~StallM)` pairing.

Latent: needs `ZCA_SUPPORTED=0` with `ZICSR_SUPPORTED=1`, which no shipped or derivative config builds — synthesis removes the flop entirely in shipped configs. Fixed so the RTL is correct independent of configuration.

Independent of the other three PRs for this issue; they apply in any order.

**Verification:** `lint-wally` and `lint-wally --nightly` clean. All 44 `tests/coverage` ELFs on rv64gc are cycle-identical to `main`, as expected where the term is constant 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013H8QE6RS2J9nJu1x4sThUh
