### PR TITLE
IEU: clear bit 0 of the jalr target (#1838 item 5)

### DIFF
--- a/src/ieu/datapath.sv
+++ b/src/ieu/datapath.sv
@@ -85,6 +85,7 @@ module datapath import cvw::*;  #(parameter cvw_t P) (
   logic [P.XLEN-1:0] ImmExtE;                        // Extended immediate in Execute stage
   logic [P.XLEN-1:0] SrcAE, SrcBE;                   // ALU operands
   logic [P.XLEN-1:0] ALUResultE, AltResultE, IEUResultE; // ALU result, Alternative result (ImmExtE or PC+4), result of execution stage
+  logic [P.XLEN-1:0] IEUAdrRawE;                     // ALU sum before clearing bit 0 of a jump target
   // Memory stage signals
   logic [P.XLEN-1:0] IEUResultM;                     // Result from execution stage
   logic [P.XLEN-1:0] IFResultM;                      // Result from either IEU or single-cycle FPU op writing an integer register
@@ -109,7 +110,10 @@ module datapath import cvw::*;  #(parameter cvw_t P) (
   comparator #(P.XLEN) comp(ForwardedSrcAE, ForwardedSrcBE, BranchSignedE, FlagsE);
   mux2  #(P.XLEN)  srcamux(ForwardedSrcAE, PCE, ALUSrcAE, SrcAE);
   mux2  #(P.XLEN)  srcbmux(ForwardedSrcBE, ImmExtE, ALUSrcBE, SrcBE);
-  alu   #(P)       alu(SrcAE, SrcBE, W64E, UW64E, SubArithE, ALUSelectE, BSelectE, ZBBSelectE, Funct3E, Funct7E, Rs2E, BALUControlE, BMUActiveE, CZeroE, ALUResultE, IEUAdrE);
+  alu   #(P)       alu(SrcAE, SrcBE, W64E, UW64E, SubArithE, ALUSelectE, BSelectE, ZBBSelectE, Funct3E, Funct7E, Rs2E, BALUControlE, BMUActiveE, CZeroE, ALUResultE, IEUAdrRawE);
+  // jalr sets the least significant bit of the target address to zero.  jal and branch targets are
+  // always even, so masking on JumpE alone is sufficient and leaves load/store addresses untouched.
+  assign IEUAdrE = {IEUAdrRawE[P.XLEN-1:1], IEUAdrRawE[0] & ~JumpE};
   mux2  #(P.XLEN)  altresultmux(ImmExtE, PCLinkE, JumpE, AltResultE);
   mux2  #(P.XLEN)  ieuresultmux(ALUResultE, AltResultE, ALUResultSrcE, IEUResultE);
 


### PR DESCRIPTION
Issue #1838 item 5.

`jalr` clears the least significant bit of its target. Wally cleared it on the fetch path but `IEUAdrE` carried the raw ALU sum, so `xtval` for an instruction-address-misaligned trap could report an odd address where the architectural target, and Sail, have bit 0 clear.

The mask is applied in `datapath.sv` where `IEUAdrE` is formed — the ALU can't do it, since `Sum` also feeds `FullResult` and the comparator flags. `JumpE` alone suffices: `jal` targets are already even and `JumpE` is 0 for every load/store, so the LSU path is untouched.

Fixing it at the source also repairs the consumers that inherited the odd bit: `BPWrongE` stops firing on a *correct* prediction of an odd `jalr` target, and the BTB stops storing the odd target, which previously re-triggered that flush on every later execution.

Independent of the other three PRs for this issue; they apply in any order.

**Verification:** `lint-wally` and `lint-wally --nightly` clean. All 44 `tests/coverage` ELFs on rv64gc are cycle-identical to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013H8QE6RS2J9nJu1x4sThUh
